### PR TITLE
Update lang.py with correct Romanian language option

### DIFF
--- a/anki/lang.py
+++ b/anki/lang.py
@@ -31,7 +31,7 @@ langs = [
     ("Polski", "pl"),
     ("Português Brasileiro", "pt_BR"),
     ("Português", "pt"),
-    ("Româneşte", "ro"),
+    ("Română", "ro"),
     ("Slovenčina", "sk"),
     ("Slovenščina", "sl"),
     ("Suomi", "fi"),


### PR DESCRIPTION
The Romanian option in the language selection screen was of a regional equivalent for the words. „Romanian language” translates to „limba română”, so the option should be „Română”.